### PR TITLE
Require pyusb 1.0.0, instead of 1.0.0b1

### DIFF
--- a/pypi/setup.py
+++ b/pypi/setup.py
@@ -23,7 +23,7 @@ setup(
     packages=['blink1', 'blink1_tests'],
     zip_safe=True,
     include_package_data=False,
-    install_requires=['pyusb>=1.0.0b1', 'click', 'webcolors'],
+    install_requires=['pyusb>=1.0.0', 'click', 'webcolors'],
     test_suite='nose.collector',
     tests_require=['mock', 'nose', 'coverage'],
     url=PROJECT_URL,


### PR DESCRIPTION
Do not depend on the beta version of PyUSB, as it exposes a deprecated API.