### PR TITLE
Multiple device support

### DIFF
--- a/alternative_libraries/blink1.py
+++ b/alternative_libraries/blink1.py
@@ -12,12 +12,12 @@ try:
     from blink1_pyusb import Blink1 as Blink1_pyusb
     use_pyusb = True
     #sys.modules['Blink1'] = blink1_pyusb
-    if debugimport: print "using blink1_pyusb"
+    print "using blink1_pyusb"
 except ImportError:
     try: 
         from blink1_ctypes import Blink1 as Blink1_ctypes
         #sys.modules['Blink1'] = blink1_ctypes
-        if debugimport: print "using blink1_ctypes" 
+        print "using blink1_ctypes" 
     except ImportError:
         print "couldn't load blink1_pyusb or blink1_ctypes"
         sys.exit(1)
@@ -32,13 +32,13 @@ class Blink1:
     and then proxies the unhandled getattribute methods to it.
     Other classes are to inherit from it.
     '''
-    def __init__(self):
+    def __init__(self, unit=0):
         '''
         Wrapper constructor.
         '''
         # wrap the object
         if use_pyusb : 
-            blink1 = Blink1_pyusb()
+            blink1 = Blink1_pyusb(unit)
         else : 
             blink1 = Blink1_ctypes()
         self._wrapped_obj = blink1

--- a/alternative_libraries/blink1_pyusb.py
+++ b/alternative_libraries/blink1_pyusb.py
@@ -34,14 +34,40 @@ debug_rw = False
 
 class Blink1:
 
-    def __init__(self):
+    def __init__(self, unit=0):
         self.dev = None
+        self.unit = unit
         return self.find()
     
     def find(self):
-        self.dev = usb.core.find(idVendor=0x27b8, idProduct=0x01ed)
-        if( self.dev == None ): 
+        devs = usb.core.find(find_all=True, idVendor=0x27b8, idProduct=0x01ed)
+
+        #self.dev = usb.core.find(find_all=True, idVendor=0x27b8, idProduct=0x01ed)
+        #print len(self.dev)
+#        if( self.dev == None ): 
+#            return None
+
+#        else:
+#	    print self.dev
+
+        if devs == None:
+            # no devices found
             return None
+
+        else:
+            # we're given an iterable so convert to a list
+            list = []
+            for cfg in devs:
+                list.append(cfg)
+#                print cfg
+#                for i in cfg:
+#                    print i.bInterfaceNumber
+
+            if self.unit >= len(list):
+                print "No device at unit " + str(self.unit)
+                return
+
+            self.dev = list[self.unit]
 
         #print "kernel_driver_active:%i" % (self.dev.is_kernel_driver_active(0))
         if( self.dev.is_kernel_driver_active(0) ):


### PR DESCRIPTION
Can now specify 'unit' parameter when creating Blink() object which allows for access to multiple devices connected to the same machine